### PR TITLE
Use constraints package to define 'number' type. Enable calling sum o…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require github.com/stretchr/testify v1.7.1
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/exp v0.0.0-20220428152302-39d4317da171 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/exp v0.0.0-20220428152302-39d4317da171 h1:TfdoLivD44QwvssI9Sv1xwa5DcL5XQr4au4sZ2F2NV4=
+golang.org/x/exp v0.0.0-20220428152302-39d4317da171/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/sliceutils/sliceutils.go
+++ b/sliceutils/sliceutils.go
@@ -3,6 +3,8 @@
 
 package sliceutils
 
+import "golang.org/x/exp/constraints"
+
 // Filter - given a slice of type T, executes the given predicate function on each element in the slice.
 // The predicate is passed the current element, the current index and the slice itself as function arguments.
 // If the predicate returns true, the value is included in the result, otherwise it is filtered out.
@@ -176,7 +178,7 @@ func Merge[T any](slices ...[]T) (mergedSlice []T) {
 
 // numbers - an interface for all number types.
 type numbers interface {
-	int | uint | uint8 | uint16 | uint32 | uint64 | int8 | int16 | int32 | int64 | float32 | float64 | complex64 | complex128
+	constraints.Complex | constraints.Integer | constraints.Float
 }
 
 // Sum - receives a slice of type T and returns a value T that is the sum of the numbers.

--- a/sliceutils/sliceutils_test.go
+++ b/sliceutils/sliceutils_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type MyInt int
+
 var numerals = []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+var numeralsWithUserDefinedType = []MyInt{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 var days = []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"}
 var lastNames = []string{"Jacobs", "Vin", "Jacobs", "Smith"}
 
@@ -146,6 +149,11 @@ func TestMerge(t *testing.T) {
 func TestSum(t *testing.T) {
 	result := sliceutils.Sum(numerals)
 	assert.Equal(t, 45, result)
+}
+
+func TestSum2(t *testing.T) {
+	result := sliceutils.Sum(numeralsWithUserDefinedType)
+	assert.Equal(t, MyInt(45), result)
 }
 
 func TestRemove(t *testing.T) {


### PR DESCRIPTION
Currently I cannot call sliceutils.Sum() with user-defined type. To fix this issue I suggest using constraints package. Alternatively, if You do not want to import additional module, 'number' interface can be fixed by using '~'
type numbers interface {
~int | ...
}

Have a nice day!