### PR TITLE
Fixing pad function, to prevent output to be too long due to a multi …

### DIFF
--- a/docs/stringutils/padLeft.md
+++ b/docs/stringutils/padLeft.md
@@ -3,6 +3,7 @@
 `func PadLeft(str string, padWith string, padTo int) string`
 
 PadLeft - Pad a string to a certain length with another string on the left side.
+If padding string is more than one char, it might be trucated to fit padTo size.
 
 ```go
 package main
@@ -14,7 +15,9 @@ import (
 
 func main() {
 	result := stringutils.PadLeft("Azer", "_", 7) // "___Azer"
-
 	fmt.Print(result) // "___Azer"
+
+	result = stringutils.PadLeft("Azer", "_-", 7) // "_-_Azer"
+	fmt.Print(result) // "_-_Azer"
 }
 ```

--- a/docs/stringutils/padRight.md
+++ b/docs/stringutils/padRight.md
@@ -3,6 +3,7 @@
 `func PadRight(str string, padWith string, padTo int) string`
 
 PadRight - Pad a string to a certain length with another string on the right side.
+If padding string is more than one char, it might be trucated to fit padTo size.
 
 ```go
 package main
@@ -14,7 +15,10 @@ import (
 
 func main() {
 	result := stringutils.PadRight("Azer", "_", 7) // "Azer___"
-
 	fmt.Print(result) // "Azer___"
+
+
+	result = stringutils.PadRight("Azer", "_-", 7) // "Azer_-_"
+	fmt.Print(result) // "Azer_-_"
 }
 ```

--- a/stringutils/stringutils.go
+++ b/stringutils/stringutils.go
@@ -160,22 +160,23 @@ func Stringify(value any, opts ...Options) string {
 
 // PadLeft - Pad a string to a certain length with another string on the left side.
 func PadLeft(str string, padWith string, padTo int) string {
-	padding := ""
 	strLen := len(str)
-	for i := 0; i < padTo-strLen; i++ {
-		padding += padWith
-	}
 
-	return padding + str
+	return getPaddingString(padWith, padTo-strLen) + str
 }
 
 // PadRight - Pad a string to a certain length with another string on the right side.
 func PadRight(str string, padWith string, padTo int) string {
-	padding := ""
 	strLen := len(str)
-	for i := 0; i < padTo-strLen; i++ {
+
+	return str + getPaddingString(padWith, padTo-strLen)
+}
+
+func getPaddingString(padWith string, padLength int) string {
+	padding := ""
+	for i := 0; i <= padLength; i++ {
 		padding += padWith
 	}
 
-	return str + padding
+	return padding[:padLength]
 }

--- a/stringutils/stringutils_test.go
+++ b/stringutils/stringutils_test.go
@@ -202,9 +202,9 @@ func TestStringify(t *testing.T) {
 }
 
 func TestPadLeft(t *testing.T) {
-	assert.Equal(t, "___Azer", stringutils.PadLeft("Azer", "_", 7))
+	assert.Equal(t, "_-_Azer", stringutils.PadLeft("Azer", "_-", 7))
 }
 
 func TestPadRight(t *testing.T) {
-	assert.Equal(t, "Azer___", stringutils.PadRight("Azer", "_", 7))
+	assert.Equal(t, "Azer-_-", stringutils.PadRight("Azer", "-_", 7))
 }


### PR DESCRIPTION
…char pad string

Updated pad functions to take into account pad string length and prevent the output to be too long by truncating pad string

`stringutils.PadRight("Azer", "ab", 7) // Azeraba`