### PR TITLE
(chore): add findIndexBy function to sliceutils

### DIFF
--- a/docs/sliceutils/findIndexBy.md
+++ b/docs/sliceutils/findIndexBy.md
@@ -1,0 +1,23 @@
+# FindIndexBy
+
+`func FindIndexBy[T comparable](input []T, predicate func(value T) bool) int`
+
+FindIndexBy takes a slice of type T and a predicate and returns the index of the
+first element that satisfies the predicate, and `-1` otherwise.
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/Goldziher/go-utils/sliceutils"
+)
+
+func main() {
+	numbers := []int{1,2,3,4,5,6}
+
+	result := sliceutils.FindIndexBy(numbers, func(value int) bool { return value % 2 == 0 })
+	fmt.Print(result) // 1
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
       - sliceutils/filter.md
       - sliceutils/find.md
       - sliceutils/findIndex.md
+      - sliceutils/findIndexBy.md
       - sliceutils/findIndexOf.md
       - sliceutils/findIndexes.md
       - sliceutils/findIndexesOf.md

--- a/sliceutils/sliceutils.go
+++ b/sliceutils/sliceutils.go
@@ -373,3 +373,14 @@ func Flatten[I any](input [][]I) (output []I) {
 	}
 	return output
 }
+
+// FindIndexBy - receives a slice of type T and a predicate and returns the index of the
+// first element that satisfies the predicate, and -1 otherwise
+func FindIndexBy[T comparable](input []T, predicate func(value T) bool) int {
+	for idx := range input {
+		if predicate(input[idx]) {
+			return idx
+		}
+	}
+	return -1
+}

--- a/sliceutils/sliceutils_test.go
+++ b/sliceutils/sliceutils_test.go
@@ -299,3 +299,10 @@ func TestFlatten(t *testing.T) {
 
 	assert.Nil(t, sliceutils.Flatten([][]int{{}, nil}))
 }
+
+func TestFindIndexBy(t *testing.T) {
+	expectedResult := 2
+	actualResult := sliceutils.FindIndexBy(numerals, func(val int) bool { return val%2 == 0 && val > 1 })
+	assert.Equal(t, expectedResult, actualResult)
+	assert.Equal(t, -1, sliceutils.FindIndexBy(numerals, func(val int) bool { return val > 100 }))
+}


### PR DESCRIPTION
Adds a util function to `sliceutils` to find the index of the element of the slice which satisfies the given predicate function.
Adds unit test for the same.