### PR TITLE
Fix FindLastIndex function to iterate over the entire slice

### DIFF
--- a/sliceutils/sliceutils.go
+++ b/sliceutils/sliceutils.go
@@ -92,7 +92,7 @@ func FindIndexOf[T comparable](slice []T, value T) int {
 // FindLastIndex - given a slice of type T, executes the passed in predicate function for each element in the slice starting from its end.
 // If no element is found, -1 is returned. The function is passed the current element, the current index and the slice itself as function arguments.
 func FindLastIndex[T any](slice []T, predicate func(value T, index int, slice []T) bool) int {
-	for i := len(slice) - 1; i > 0; i-- {
+	for i := len(slice) - 1; i >= 0; i-- {
 		el := slice[i]
 		if ok := predicate(el, i, slice); ok {
 			return i

--- a/sliceutils/sliceutils_test.go
+++ b/sliceutils/sliceutils_test.go
@@ -115,6 +115,10 @@ func TestFindLastIndex(t *testing.T) {
 			return value == "Hamudi"
 		}),
 	)
+
+	assert.Equal(t, 0, sliceutils.FindLastIndex(days, func(value string, index int, slice []string) bool {
+		return value == "Sunday"
+	}))
 }
 
 func TestFindLastIndexOf(t *testing.T) {


### PR DESCRIPTION
FindLastIndex wasn't finding the index if the matching element was in position zero due to an `i > 0` iteration condition that should be `i >= 0`.

Added a test case that fails without this fix.